### PR TITLE
feat: support comment option

### DIFF
--- a/.changeset/dark-weeks-relax.md
+++ b/.changeset/dark-weeks-relax.md
@@ -1,0 +1,5 @@
+---
+"generate-external-type": patch
+---
+
+Supports JSDoc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  test:
-    name: Test
+  test-ubuntu-latest:
+    name: Test (ubuntu-latest)
     runs-on: ubuntu-latest
     needs: [build,lint]
     steps:
@@ -64,6 +64,25 @@ jobs:
       - name: Run tests
         run: npm run test:run
 
+  test-windows-latest:
+    name: Test (windows-latest)
+    runs-on: windows-latest
+    needs: [build,lint]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:run
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ generateExternalType({
   - **`options`**: Optional glob options (e.g., `ignore`, `dot`, `follow`), see [GlobOptions](https://github.com/isaacs/node-glob?tab=readme-ov-file#options) from `glob`
 - **`output`**: File path to save the generated type definitions
 - **`extractor`**: Function that takes `FilesMap` and returns `GeneratedType[]`
+- **`comment`**: Optional comment to write at the beginning of the output file
 
 ## 🔧 Type Definitions
 
@@ -51,6 +52,7 @@ type GeneratedType = GeneratedBaseType & (GeneratedUnionType | GeneratedInterfac
 
 interface GeneratedBaseType {
   name: string;  // Type name
+  jsDoc?: string;  // JSDoc comment for the type
 }
 
 interface GeneratedUnionType {
@@ -609,6 +611,107 @@ export default function BlogPost({ params }: BlogPostProps) {
 ```
 
 This example demonstrates how to automatically generate type-safe route definitions for Next.js App Router, making your navigation and parameter handling completely type-safe!
+
+### Example 6: JSDoc Comments and File Header Comments
+
+**Type generation script:**
+
+```typescript
+import generateExternalType from 'generate-external-type';
+
+generateExternalType({
+  scanOption: {
+    pattern: './src/config/**/*.json',
+  },
+  output: './src/generated/config-types.ts',
+  comment: 'Auto-generated type definitions for configuration files.',
+  extractor: (files) => {
+    const types: GeneratedType[] = [];
+    
+    for (const [filePath, content] of files) {
+      const data = JSON.parse(content);
+      
+      if (filePath.includes('database')) {
+        types.push({
+          name: 'DatabaseConfig',
+          type: 'interface',
+          properties: {
+            host: 'string',
+            port: 'number',
+            username: 'string',
+            password: 'string',
+            database: 'string'
+          },
+          jsDoc: 'Database configuration interface with connection settings.'
+        });
+      }
+      
+      if (filePath.includes('api')) {
+        types.push({
+          name: 'ApiConfig',
+          type: 'interface',
+          properties: {
+            baseUrl: 'string',
+            timeout: 'number',
+            retries: 'number',
+            enableCache: 'boolean'
+          },
+          jsDoc: 'API configuration settings for external service communication.'
+        });
+      }
+      
+      if (filePath.includes('features')) {
+        types.push({
+          name: 'FeatureFlags',
+          type: 'union',
+          members: Object.keys(data),
+          jsDoc: 'Available feature flags for the application.'
+        });
+      }
+    }
+    
+    return types;
+  }
+});
+```
+
+**Generated output (`./src/generated/config-types.ts`):**
+
+```typescript
+// Auto-generated type definitions for configuration files.
+
+/**
+ * Database configuration interface with connection settings.
+ */
+export interface DatabaseConfig {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  database: string;
+}
+
+/**
+ * API configuration settings for external service communication.
+ */
+export interface ApiConfig {
+  baseUrl: string;
+  timeout: number;
+  retries: number;
+  enableCache: boolean;
+}
+
+/**
+ * Available feature flags for the application.
+ */
+export type FeatureFlags = "darkMode" | "notifications" | "analytics" | "premium";
+```
+
+**Key Features:**
+
+1. **File Header Comment**: The `comment` option adds a header comment to the entire generated file
+2. **JSDoc Comments**: Each type can have its own JSDoc comment using the `jsDoc` property
+3. **Simple Usage**: Just write the content - formatting is handled automatically
 
 ## 🛠️ Development
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
 import fs from "fs";
 
 import type { ExtractExternalOptions } from "./type";
-import { getTypeContent, scanFiles } from "./utils";
+import { getContent, scanFiles } from "./utils";
 
 export default function generateExternalType({
   scanOption,
   output,
   extractor,
+  comment,
 }: ExtractExternalOptions) {
   const files = scanFiles(scanOption);
   const types = extractor(files);
-  const content = getTypeContent(types);
+  const content = getContent(types, comment);
   fs.writeFileSync(output, content);
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -39,6 +39,10 @@ export interface GeneratedBaseType {
    * name of the type.
    */
   name: string;
+  /**
+   * jsDoc of the type. Don't write format of jsDoc at the beginning and the end.
+   */
+  jsDoc?: string;
 }
 
 export type GeneratedType = GeneratedBaseType &
@@ -64,4 +68,8 @@ export interface ExtractExternalOptions {
    * extract type from files.
    */
   extractor: (files: FilesMap) => GeneratedType[];
+  /**
+   * comment to write at the beginning of the output file.
+   */
+  comment?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,9 +12,26 @@ export function scanFiles(scanOption: ScanOption) {
   return fileMap;
 }
 
-export function getTypeContent(types: GeneratedType[]) {
+export function getContent(types: GeneratedType[], comment?: string) {
+  function writeJsDoc(jsDoc?: string) {
+    if (!jsDoc) {
+      return "";
+    }
+    const lines = jsDoc.split("\n");
+    const indentedLines = lines.map((line) => `*  ${line}`);
+    return `/**\n${indentedLines.join("\n")}\n*/\n`;
+  }
+
   let content = "";
+  if (comment) {
+    const lines = comment.split("\n");
+    const indentedLines = lines.map((line) => `// ${line}`);
+    content += `${indentedLines.join("\n")}\n`;
+    content += "\n";
+  }
+  
   types.forEach((type) => {
+    content += writeJsDoc(type.jsDoc);
     if (type.type === "union") {
       const membersSet = new Set<string>();
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,8 +18,8 @@ export function getContent(types: GeneratedType[], comment?: string) {
       return "";
     }
     const lines = jsDoc.split("\n");
-    const indentedLines = lines.map((line) => `*  ${line}`);
-    return `/**\n${indentedLines.join("\n")}\n*/\n`;
+    const indentedLines = lines.map((line) => ` *  ${line}`);
+    return `/**\n${indentedLines.join("\n")}\n */\n`;
   }
 
   let content = "";

--- a/tests/getContent.test.ts
+++ b/tests/getContent.test.ts
@@ -1,8 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { getTypeContent } from "../src/utils";
+import { getContent } from "../src/utils";
 import type { GeneratedType } from "../src/type";
 
-describe("getTypeContent", () => {
+describe("getContent", () => {
+  it("should write comment at the beginning of the output file", () => {
+    const types: GeneratedType[] = [{
+      name: "Status",
+      type: "union",
+      members: ["active", "inactive", "pending"],
+    }];
+    const result = getContent(types, "This is a comment");
+    expect(result).toContain(`// This is a comment
+
+export type Status = "active" | "inactive" | "pending";`);
+  });
+
   it("should generate union type content", () => {
     const types: GeneratedType[] = [
       {
@@ -12,7 +24,7 @@ describe("getTypeContent", () => {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(
       'export type Status = "active" | "inactive" | "pending"'
     );
@@ -29,7 +41,7 @@ describe("getTypeContent", () => {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(
       'export type NullableString = "hello" | "world" | null | undefined'
     );
@@ -46,7 +58,7 @@ describe("getTypeContent", () => {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(
       'export type TestType = "value" | null | undefined'
     );
@@ -65,7 +77,7 @@ describe("getTypeContent", () => {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(`export interface User {
   id: number;
   name: string;
@@ -90,7 +102,7 @@ describe("getTypeContent", () => {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(`export type Status = "active" | "inactive";
 
 export interface Config {
@@ -100,7 +112,7 @@ export interface Config {
   });
 
   it("should handle empty types array", () => {
-    const result = getTypeContent([]);
+    const result = getContent([]);
     expect(result).toBe("");
   });
 
@@ -113,9 +125,26 @@ export interface Config {
       },
     ];
 
-    const result = getTypeContent(types);
+    const result = getContent(types);
     expect(result).toContain(
       'export type Priority = 1 | 2 | 3 | "high" | "low"'
     );
+  });
+
+  it("should write jsDoc", () => {
+    const types: GeneratedType[] = [
+      {
+        name: "Priority",
+        type: "union",
+        members: [1, 2],
+        jsDoc: `This is a jsDoc`,
+      },
+    ];
+
+    const result = getContent(types);
+    expect(result).toContain(`/**
+*  This is a jsDoc
+*/
+export type Priority = 1 | 2;`);
   });
 });

--- a/tests/getContent.test.ts
+++ b/tests/getContent.test.ts
@@ -143,8 +143,8 @@ export interface Config {
 
     const result = getContent(types);
     expect(result).toContain(`/**
-*  This is a jsDoc
-*/
+ *  This is a jsDoc
+ */
 export type Priority = 1 | 2;`);
   });
 });


### PR DESCRIPTION
Write comment on beginning of the file and JSDoc on the each type.
TODO: docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Generated outputs can include per-type JSDoc comments and an optional file header comment.
  - Public options extended to accept a header comment; generated types can carry an optional jsDoc.

- Documentation
  - README updated with Example 6 showing JSDoc and header comment usage and key feature highlights.

- Tests
  - Added tests for header comments and per-type JSDoc; updated existing cases.

- Chores
  - Added release metadata for a patch noting JSDoc support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->